### PR TITLE
readme: fix example usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,10 +9,10 @@ Example usage in `.pre-commit-config.yaml`:
 ```
 ---
 repos:
-  - repo: https://github.com/thoth-station/test-thoth-pre-commit-hook
     rev: v0.1.0
+  - repo: https://github.com/thoth-station/thoth-pre-commit-hook
     hooks:
-      - id: thoth-advise
+      - id: thoth-pre-commit-hook
         args: ["--recommendation-type", "security"]
 ```
 

--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@ Example usage in `.pre-commit-config.yaml`:
 ```
 ---
 repos:
-    rev: v0.1.0
   - repo: https://github.com/thoth-station/thoth-pre-commit-hook
+    rev: v0.1.1
     hooks:
       - id: thoth-pre-commit-hook
         args: ["--recommendation-type", "security"]


### PR DESCRIPTION
### Description
This change corrects repo name and pre-commit hook id in the readme example usage.