### PR TITLE
do not pass file arguments from pre-commit to thanos

### DIFF
--- a/thoth/thoth_pre_commit_hook/thoth_advise.py
+++ b/thoth/thoth_pre_commit_hook/thoth_advise.py
@@ -24,6 +24,7 @@ import sys
 
 def main():
     """Entrypoint for thoth-pre-commit-hook."""
+    subprocess.run(["thamos", "config"])
     subprocess.run(["thamos", "check"])
 
     # thamos doesn't accept actual paths and that's what pre-commit is passing

--- a/thoth/thoth_pre_commit_hook/thoth_advise.py
+++ b/thoth/thoth_pre_commit_hook/thoth_advise.py
@@ -17,6 +17,7 @@
 
 """Thoth pre-commit hook entrypoint."""
 
+import os
 import subprocess
 import sys
 
@@ -24,7 +25,14 @@ import sys
 def main():
     """Entrypoint for thoth-pre-commit-hook."""
     subprocess.run(["thamos", "check"])
-    advise_subprocess = subprocess.run(["thamos", "advise", *sys.argv[1:]])
+
+    # thamos doesn't accept actual paths and that's what pre-commit is passing
+    thamos_args = []
+    for a in sys.argv:
+        if not os.path.exists(a):
+            thamos_args += a
+
+    advise_subprocess = subprocess.run(["thamos", "advise"] + thamos_args)
     return advise_subprocess.returncode
 
 


### PR DESCRIPTION
### Description
also:
```
run `thamos config` before running advise

`advise` won't run if there is no .thoth.yaml
```

I needed these two commits for the pre-commit to start getting results from thamos