### PR TITLE
run thamos config non interactively

### DIFF
--- a/thoth/thoth_pre_commit_hook/thoth_advise.py
+++ b/thoth/thoth_pre_commit_hook/thoth_advise.py
@@ -24,7 +24,7 @@ import sys
 
 def main():
     """Entrypoint for thoth-pre-commit-hook."""
-    subprocess.run(["thamos", "config"])
+    subprocess.run(["thamos", "config", "--no-interactive"])
     subprocess.run(["thamos", "check"])
 
     # thamos doesn't accept actual paths and that's what pre-commit is passing


### PR DESCRIPTION
## This should yield a new module release

- Yes

Sorry, without this change the pre-commit hook is broken if there is no .thoth.yaml

### Description

Run `thamos config` non-interactively. When `pre-commit` gets invoked, thamos opens an editor to edit the config. User never sees that editor so the run looks stuck.

Sorry for the breakage.