### PR TITLE
print analysis URL to stdout if it's known

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -7,4 +7,5 @@
   require_serial: false
   verbose: true
   always_run: true
+  pass_filenames: false
   files: ''

--- a/thoth/thoth_pre_commit_hook/thoth_advise.py
+++ b/thoth/thoth_pre_commit_hook/thoth_advise.py
@@ -17,7 +17,7 @@
 
 """Thoth pre-commit hook entrypoint."""
 
-import os
+import re
 import subprocess
 import sys
 
@@ -29,7 +29,19 @@ def main():
 
     thamos_args = sys.argv[1:]
 
-    advise_subprocess = subprocess.run(["thamos", "advise"] + thamos_args)
+    advise_subprocess = subprocess.run(
+        ["thamos", "advise"] + thamos_args, stdout=subprocess.PIPE
+    )
+    stdout = advise_subprocess.stdout.decode(sys.getdefaultencoding())
+    # let's print advise's output to the console nevertheless
+    print(stdout)
+    try:
+        advise_id = re.findall(r"adviser-\w+-\w+", stdout)[0]
+    except IndexError:
+        advise_id = None
+
+    if advise_id:
+        print(f"Advise output: https://thoth-station.ninja/search/advise/{advise_id}/")
     return advise_subprocess.returncode
 
 

--- a/thoth/thoth_pre_commit_hook/thoth_advise.py
+++ b/thoth/thoth_pre_commit_hook/thoth_advise.py
@@ -27,11 +27,7 @@ def main():
     subprocess.run(["thamos", "config", "--no-interactive"])
     subprocess.run(["thamos", "check"])
 
-    # thamos doesn't accept actual paths and that's what pre-commit is passing
-    thamos_args = []
-    for a in sys.argv:
-        if not os.path.exists(a):
-            thamos_args += a
+    thamos_args = sys.argv[1:]
 
     advise_subprocess = subprocess.run(["thamos", "advise"] + thamos_args)
     return advise_subprocess.returncode


### PR DESCRIPTION
## This introduces a breaking change
<!-- Leave one of the options -->

- No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## This should yield a new module release

- Yes

Would be lovely!

<!-- If this change modifies the behavior of the module, specify that it should yield a new minor release. -->

## This Pull Request implements

1. Searches for advise ID in the stdout and constructs a URL so anyone can click and see the results in browser

2. Uses pre-commit's native way of not passing files to the hook

### Description

Since `thamos advise` prints a ton of output by default, I wanted to come up with
a "noninvasive" workflow for my team. It consists of running this hook via
`thamos advise --no-wait --json` and just printing the URL to stdout so folks
are free to explore the analysis.

Example run: https://softwarefactory-project.io/zuul/t/packit-service/build/937f55542c4f46a18c751cf288ae734e/console